### PR TITLE
Overridable center style

### DIFF
--- a/index.js
+++ b/index.js
@@ -187,7 +187,7 @@ var SlideMenu = React.createClass({
             {menu}
           </View>
           <View
-            style={[styles.center, frontWayStyle]}
+            style={[styles.center, frontWayStyle, this.props.centerStyle]}
             ref={(center) => this.center = center}
             {...this._panGesture.panHandlers}>
             {this.props.frontView}
@@ -211,7 +211,7 @@ var SlideMenu = React.createClass({
       return (
         <View style={[styles.containerSlideMenu, this.props.style]}>
           <View
-            style={[styles.center]}
+            style={[styles.center, this.props.centerStyle]}
             ref={(center) => this.center = center}
             {...this._panGesture.panHandlers}>
             {this.props.frontView}


### PR DESCRIPTION
This PR adds the prop centerStyle to allow the style of the main center View to be overridden.

The impetus of the update was the need to change the background from the default white to transparent.

README.md was not updated since style was not already referencing style usage.
