### PR TITLE
Removed conflicting react-native dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,8 +25,5 @@
   "bugs": {
     "url": "https://github.com/ilansas/react-native-navigation-drawer/issues"
   },
-  "homepage": "https://github.com/ilansas/react-native-navigation-drawer",
-  "dependencies": {
-    "react-native": "^0.6.0"
-  }
+  "homepage": "https://github.com/ilansas/react-native-navigation-drawer"
 }


### PR DESCRIPTION
Removing `react-native` dependency as it is unneeded and causes conflicts in projects
